### PR TITLE
Create an EVM package

### DIFF
--- a/contracts/FixidityLib.sol
+++ b/contracts/FixidityLib.sol
@@ -225,7 +225,7 @@ library FixidityLib {
     /**
      * @notice Converts an int256 which is already in some fixed point 
      * representation to that of this library. The _originDigits parameter is the
-     * precision of x. Values with a precision higher than FixidityLib.digits()
+     * precision of x. Values with a precision higher than digits()
      * will be truncated accordingly.
      */
     function newFixed(int256 x, uint8 _originDigits)
@@ -240,7 +240,7 @@ library FixidityLib {
      * @notice Converts an int256 in the fixed point representation of this 
      * library to a different representation. The _destinationDigits parameter is the
      * precision of the output x. Values with a precision below than 
-     * FixidityLib.digits() will be truncated accordingly.
+     * digits() will be truncated accordingly.
      */
     function fromFixed(int256 x, uint8 _destinationDigits)
         public
@@ -439,5 +439,98 @@ library FixidityLib {
         assert(y != 0);
         assert(y <= maxFixedDivisor());
         return multiply(x, reciprocal(y));
+    }
+
+    /**
+     * @notice This is e in the fixed point units used in this library.
+     * @dev 27182818284590452353602874713526624977572470936999595749669676277240766303535/fixed1()
+     * Hardcoded to 24 digits.
+     */
+    function fixedE() public pure returns(int256) {
+        return 2718281828459045235360287;
+    }
+
+    /**
+     * @notice ln(1.5), hardcoded with the comma 24 positions to the right.
+     */
+    // solium-disable-next-line mixedcase
+    function fixedLn1_5() public pure returns(int256) {
+        return 405465108108164381978013;
+    }
+
+    /**
+     * @notice ln(10), hardcoded with the comma 24 positions to the right.
+     */
+    function fixedLn10() public pure returns(int256) {
+        return 2302585092994045684017991;
+    }
+
+    /**
+     * @notice ln(x)
+     * This function has a 1/50 deviation close to ln(-1), 
+     * 1/maxFixedMul() deviation at fixedE()**2, but diverges to 10x 
+     * deviation at maxNewFixed().
+     * @dev 
+     * Test ln(0) fails
+     * Test ln(-fixed1()) fails
+     * Test ln(fixed1()) returns 0
+     * Test ln(fixedE()) returns fixed1()
+     * Test ln(fixedE()*fixedE()) returns ln(fixedE())+ln(fixedE())
+     * Test ln(maxInt256) returns 176752531042786059920093411119162458112
+     * Test ln(1) returns -82
+     */
+    function ln(int256 value) public pure returns (int256) {
+        assert(value >= 0);
+        int256 v = value;
+        int256 r = 0;
+        while (v <= fixed1() / 10) {
+            v = v * 10;
+            r -= fixedLn10();
+        }
+        while (v >= 10 * fixed1()) {
+            v = v / 10;
+            r += fixedLn10();
+        }
+        while (v < fixed1()) {
+            v = multiply(v, fixedE());
+            r -= fixed1();
+        }
+        while (v > fixedE()) {
+            v = divide(v, fixedE());
+            r += fixed1();
+        }
+        if (v == fixed1()) {
+            return r;
+        }
+        if (v == fixedE()) {
+            return fixed1() + r;
+        }
+
+        v = v - 3 * fixed1() / 2;
+        r = r + fixedLn1_5();
+        int256 m = fixed1() * v / (v + 3 * fixed1());
+        r = r + 2 * m;
+        // solium-disable-next-line mixedcase
+        int256 m_2 = m * m / fixed1();
+        uint8 i = 3;
+        while (true) {
+            m = m * m_2 / fixed1();
+            r = r + 2 * m / int256(i);
+            i += 2;
+            if (i >= 3 + 2 * digits()) break;
+        }
+        return r;
+    }
+
+    /**
+     * @notice log_b(x).
+     * *param int256 b Base in fixed point representation.
+     * @dev Tests covered by ln(x) and divide(a,b)
+     */
+    // solium-disable-next-line mixedcase
+    function log_b(int256 b, int256 x) public pure returns (int256) {
+        if (b == fixed1()*10)
+            return divide(ln(x), fixedLn10());
+        return divide(ln(x), ln(b));
     }
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
         "eslint-plugin-import": "^2.16.0",
         "eslint-plugin-jsx-a11y": "^6.2.1",
         "eslint-plugin-react": "^7.12.4",
-        "ethlint": "1.2.3"
+        "ethlint": "1.2.3",
+	"eth-gas-reporter": "^0.1.0"
     }
 }

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -8,8 +8,7 @@ module.exports = {
     },
 
     mocha: {
-        // see more here: https://www.npmjs.com/package/eth-gas-reporter
-        // reporter: 'eth-gas-reporter',
+        reporter: 'eth-gas-reporter',
     },
 
     solc: {


### PR DESCRIPTION
While deploying it with ZeppelinOS we had to deal with the limitation of not calling libraries from libraries using public methods, which is what LogarithmLib does.
As a quick solution, we packed everything into one library only. :package: 

We are now looking forward to making an EVM-package out of it to work better with ZeppelinOS. :rocket: 