### PR TITLE
Added suggested changes from Quantstamp audit feedback.

### DIFF
--- a/contracts/ExponentLib.sol
+++ b/contracts/ExponentLib.sol
@@ -18,7 +18,7 @@ library ExponentLib {
         pure 
         returns (int256) 
     {
-        assert(_x < 172 * FixidityLib.fixed1());
+        require(_x < 172 * FixidityLib.fixed1());
         int256 x = _x;
         int256 r = FixidityLib.fixed1();
         while (x >= 10 * FixidityLib.fixed1()) {

--- a/contracts/FixidityLib.sol
+++ b/contracts/FixidityLib.sol
@@ -68,7 +68,7 @@ library FixidityLib {
     }
 
     /**
-     * @notice Maximum value that can be converted to fixed point. Optimize for
+     * @notice Minimum value that can be converted to fixed point. Optimize for
      * deployment. 
      * @dev Test minNewFixed() equals -(maxInt256()) / fixed1()
      * Hardcoded to 24 digits.
@@ -151,8 +151,8 @@ library FixidityLib {
         pure
         returns (int256)
     {
-        assert(x <= maxNewFixed());
-        assert(x >= minNewFixed());
+        require(x <= maxNewFixed());
+        require(x >= minNewFixed());
         return x * fixed1();
     }
 
@@ -199,7 +199,7 @@ library FixidityLib {
         pure
         returns (int256)
     {
-        assert(_originDigits <= 38 && _destinationDigits <= 38);
+        require(_originDigits <= 38 && _destinationDigits <= 38);
         
         uint8 decimalDifference;
         if ( _originDigits > _destinationDigits ){
@@ -214,8 +214,8 @@ library FixidityLib {
             //     decimalDifference = abs(_destinationDigits - _originDigits)
             //     decimalDifference < 38
             //     10**38 < 2**128-1
-            assert(x <= maxInt256()/uint128(10)**uint128(decimalDifference));
-            assert(x >= minInt256()/uint128(10)**uint128(decimalDifference));
+            require(x <= maxInt256()/uint128(10)**uint128(decimalDifference));
+            require(x >= minInt256()/uint128(10)**uint128(decimalDifference));
             return x*(uint128(10)**uint128(decimalDifference));
         }
         // _originDigits == digits()) 
@@ -271,9 +271,9 @@ library FixidityLib {
         pure
         returns (int256)
     {
-        assert(numerator <= maxNewFixed());
-        assert(denominator <= maxNewFixed());
-        assert(denominator != 0);
+        require(numerator <= maxNewFixed());
+        require(denominator <= maxNewFixed());
+        require(denominator != 0);
         int256 convertedNumerator = newFixed(numerator);
         int256 convertedDenominator = newFixed(denominator);
         return divide(convertedNumerator, convertedDenominator);
@@ -420,7 +420,7 @@ library FixidityLib {
      * Test reciprocal(2*fixed1()*fixed1()) returns 0 // Testing how the fractional is truncated
      */
     function reciprocal(int256 x) public pure returns (int256) {
-        assert(x != 0);
+        require(x != 0);
         return (fixed1()*fixed1()) / x; // Can't overflow
     }
 
@@ -436,8 +436,8 @@ library FixidityLib {
      */
     function divide(int256 x, int256 y) public pure returns (int256) {
         if (y == fixed1()) return x;
-        assert(y != 0);
-        assert(y <= maxFixedDivisor());
+        require(y != 0);
+        require(y <= maxFixedDivisor());
         return multiply(x, reciprocal(y));
     }
 }

--- a/contracts/LogarithmLib.sol
+++ b/contracts/LogarithmLib.sol
@@ -49,7 +49,7 @@ library LogarithmLib {
      * Test ln(1) returns -82
      */
     function ln(int256 value) public pure returns (int256) {
-        assert(value >= 0);
+        require(value >= 0);
         int256 v = value;
         int256 r = 0;
         while (v <= FixidityLib.fixed1() / 10) {


### PR DESCRIPTION
We used the Fixidity library in the smart contracts for PoolTogether.  We had the contracts audited by Quantstamp, so we thought we contribute their findings upstream.

The audit report had the feedback:

- Using `require(...)` for testing input parameters and `assert(...)`
for validating invariants
- Error on L71 "Maximum" needed to be changed to "Minimum"

Their focus was on the FixidityLib.sol contract but I've also updated the other libs to use `require`.

I hope this helps.  Thanks for the library!

🥂 