### PR TITLE
Set exact max factor in multiplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ Default: -2894802230932904885589274625217197696331749616641014100986439600197828
 Maximum value that can be safely used as a multiplication operator. 
 Divisions where a value is divided by another over this value might overflow, 
 but not necessarily so.
-Calculated as maxFixedMul() = sqrt(maxNewFixed())*fixed1().
-Default: 240615969168004511545000000000000000000000000000000000000
+Calculated as maxFixedMul() = sqrt(maxNewFixed()*fixed1()).
+Default: 240615969168004511545033772477625056927114980741063
 
 **function maxFixedDiv() public pure returns(int256)**
 Maximum value that can be safely used as a dividend.

--- a/contracts/FixidityLib.sol
+++ b/contracts/FixidityLib.sol
@@ -112,7 +112,7 @@ library FixidityLib {
      * Hardcoded to 24 digits.
      */
     function maxFixedMul() public pure returns(int256) {
-        return 240615969168004498257251713877715648331380787511296;
+        return 240615969168004511545033772477625056927114980741063;
     }
 
     /**


### PR DESCRIPTION
Computed with 

    ruby -e "maxInt256 = 57896044618658097711785492504343953926634992332820282019728792003956564819967; one = 10**24; puts (Integer.sqrt(maxInt256*one))"
